### PR TITLE
Add \n to syslog msg

### DIFF
--- a/global.go
+++ b/global.go
@@ -35,7 +35,7 @@ func GetLogger(name string) Logger {
 	return globalLoggers.Get(name)
 }
 
-// ResetLogging iterates through the known modules and sets the levels of all
+// ResetLoggers iterates through the known modules and sets the levels of all
 // to UNSPECIFIED, except for <root> which is set to WARNING.
 func ResetLoggers() {
 	globalLoggers.resetLevels()

--- a/level.go
+++ b/level.go
@@ -86,14 +86,14 @@ type HasMinLevel interface {
 	MinLogLevel() Level
 }
 
-// HasParentWithLevel represents values that have a parent that in turn
+// HasParentWithMinLevel represents values that have a parent that in turn
 // have a minimum log level.
 type HasParentWithMinLevel interface {
 	// ParentWithMinLogLevel returns the value's parent (or nil).
 	ParentWithMinLogLevel() HasMinLevel
 }
 
-// EffectiveLogMinLevel returns the effective minimum log level of the
+// EffectiveMinLevel returns the effective minimum log level of the
 // leveler. This is the level at which messages with a lower level
 // will be discarded for this leveler.
 //

--- a/syslogwriter.go
+++ b/syslogwriter.go
@@ -279,7 +279,7 @@ func (syslog *syslogWriter) Write(level Level, module, filename string, line int
 	}
 
 	header := fmt.Sprintf("<%d>1 %s %s %s %d - -", priority, timestamp.Format(rfc5424), hostname, module, os.Getpid())
-	msg := fmt.Sprintf("%s %s%s:%d %s", header, utf8bom, filename, line, message)
+	msg := fmt.Sprintf("%s %s%s:%d %s\n", header, utf8bom, filename, line, message)
 
 	syslog.bufferedMessagesCond.L.Lock()
 	syslog.bufferedMessages = append(syslog.bufferedMessages, msg)


### PR DESCRIPTION
This PR adds a line break to the end of every syslog msg.

(It also makes `gometalinter` cry less 👍)
